### PR TITLE
Add family ID 0xB0 for CCG3PA

### DIFF
--- a/src/flash/nor/psoc4.c
+++ b/src/flash/nor/psoc4.c
@@ -251,7 +251,7 @@ const struct psoc4_chip_family psoc4_families[] = {
 	{ 0xAB, "PSoC 4100S",                           .flags = 0, .spcif_ver = spcif_v3 },
 	{ 0xAC, "PSoC 4100PS/PSoC Analog Coprocessor",  .flags = 0, .spcif_ver = spcif_v3 },
 	{ 0xAE, "PSoC 4xx8 BLE",                        .flags = PSOC4_FLAG_IMO_NOT_REQUIRED, .spcif_ver = spcif_v2 },
-	{ 0xB0, "CCG3PA USB Type-C Port Controller",    .flags = 0, .spcif_ver = spcif_v3 },	
+	{ 0xB0, "CCG3PA USB Type-C Port Controller",    .flags = 0, .spcif_ver = spcif_v3 },
 	{ 0xB5, "PSoC 4100S Plus",                      .flags = 0, .spcif_ver = spcif_v3 },
 	{ 0xB8, "PSoC 4100S Plus/PSoC 4500",            .flags = 0, .spcif_ver = spcif_v3 },
 	{ 0xBE, "PSoC 4100S Max",                       .flags = 0, .spcif_ver = spcif_v3 },

--- a/src/flash/nor/psoc4.c
+++ b/src/flash/nor/psoc4.c
@@ -251,6 +251,7 @@ const struct psoc4_chip_family psoc4_families[] = {
 	{ 0xAB, "PSoC 4100S",                           .flags = 0, .spcif_ver = spcif_v3 },
 	{ 0xAC, "PSoC 4100PS/PSoC Analog Coprocessor",  .flags = 0, .spcif_ver = spcif_v3 },
 	{ 0xAE, "PSoC 4xx8 BLE",                        .flags = PSOC4_FLAG_IMO_NOT_REQUIRED, .spcif_ver = spcif_v2 },
+	{ 0xB0, "CCG3PA USB Type-C Port Controller",    .flags = 0, .spcif_ver = spcif_v3 },	
 	{ 0xB5, "PSoC 4100S Plus",                      .flags = 0, .spcif_ver = spcif_v3 },
 	{ 0xB8, "PSoC 4100S Plus/PSoC 4500",            .flags = 0, .spcif_ver = spcif_v3 },
 	{ 0xBE, "PSoC 4100S Max",                       .flags = 0, .spcif_ver = spcif_v3 },


### PR DESCRIPTION
Add family ID 0xB0 for [CCG3PA USB Type-C Port Controller](https://www.cypress.com/products/ez-pd-ccg3pa-usb-type-c-and-power-delivery)

MiniProg4 can connect to the DAP inside CCG3PA over SWD and read memory from the ROM table in the CCG3PA in `psoc4_get_family()`:
```
*****************************************
** Silicon: 0x2003, Family: 0xB0, Rev.: 0x12 (A1)
** Detected Family: CCG3PA USB Type-C Port Controller
** Detected Main Flash size, kb: 64
** Chip Protection: protection OPEN
*****************************************
```

NOTE: `kitprog3 posc_acquire` fails per issue #4
