### PR TITLE
Add silicon family ID 0xAF for CCG4

### DIFF
--- a/src/flash/nor/psoc4.c
+++ b/src/flash/nor/psoc4.c
@@ -251,6 +251,7 @@ const struct psoc4_chip_family psoc4_families[] = {
 	{ 0xAB, "PSoC 4100S",                           .flags = 0, .spcif_ver = spcif_v3 },
 	{ 0xAC, "PSoC 4100PS/PSoC Analog Coprocessor",  .flags = 0, .spcif_ver = spcif_v3 },
 	{ 0xAE, "PSoC 4xx8 BLE",                        .flags = PSOC4_FLAG_IMO_NOT_REQUIRED, .spcif_ver = spcif_v2 },
+	{ 0xAF, "CCG4 USB Type-C Port Controller",      .flags = 0, .spcif_ver = spcif_v3 },	
 	{ 0xB5, "PSoC 4100S Plus",                      .flags = 0, .spcif_ver = spcif_v3 },
 	{ 0xB8, "PSoC 4100S Plus/PSoC 4500",            .flags = 0, .spcif_ver = spcif_v3 },
 	{ 0xBE, "PSoC 4100S Max",                       .flags = 0, .spcif_ver = spcif_v3 },


### PR DESCRIPTION
Add silicon family ID 0xAF for CCG4 USB Type-C Port Controller per the [CCGx Programming Spec](https://www.cypress.com/documentation/programming-specifications/ccgx-cypdxxxx-programming-specifications)

I have tested this successfully using with the CCG4 on the Power Board of the [CY4532 EVK](https://www.cypress.com/documentation/development-kitsboards/cy4532-ez-pd-ccg3pa-evaluation-kit).  MiniProg4 was connected to J8 header.

```
make[1]: Leaving directory '/home/pdp7/dev/dojofive/bcd/openocd'
pdp7@x1:~/dev/dojofive/bcd/openocd$ openocd  -s tcl -f interface/kitprog3.cfg -f target/psoc4.cfg -c "kitprog3 power_config on 3300; kitprog3 acquire_config on 0 1 5; init; kitprog3 acquire_psoc; program CYPD3171-24LQXQ_cla.hex verify reset exit"
Open On-Chip Debugger 0.10.0+dev-gd526e667dedf-dirty (2021-02-22-17:17)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Info : auto-selecting first available session transport "swd". To override use 'transport select <transport>'.
adapter speed: 2000 kHz
** Auto-acquire enabled, use "set PSOC4_USE_ACQUIRE 0" to disable
cortex_m reset_config sysresetreq
Info : CMSIS-DAP: SWD  Supported
Info : CMSIS-DAP: JTAG Supported
Info : CMSIS-DAP: FW Version = 2.0.0
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 1 SWDIO/TMS = 1 TDI = 0 TDO = 0 nTRST = 0 nRESET = 1
Info : CMSIS-DAP: Interface ready
Info : KitProg3: FW version: 2.10.878
Info : KitProg3: Pipelined transfers enabled
Info : kitprog3: powering up target device using KitProg3 (VTarg = 3300 mV)
Info : VTarget = 3.293 V
Info : kitprog3: acquiring the device...
Info : clock speed 2000 kHz
Info : SWD DPIDR 0x0bb11477
Info : psoc4.cpu: hardware has 4 breakpoints, 2 watchpoints
*****************************************
** Silicon: 0x1F01, Family: 0xAF, Rev.: 0x13 (A2)
** Detected Family: CCG4 AF USB Type-C Port Controller
** Detected Main Flash size, kb: 128
** Chip Protection: protection OPEN
*****************************************
Info : starting gdb server for psoc4.cpu on 3333
Info : Listening on port 3333 for gdb connections
Info : kitprog3: acquiring the device...
Info : psoc4.cpu: external reset detected
Info : SWD DPIDR 0x0bb11477
Info : SWD DPIDR 0x0bb11477
Error: DP initialisation failed
Info : kitprog3: acquiring the device...
Info : SWD DPIDR 0x0bb11477
psoc4.cpu halted due to debug-request, current mode: Thread 
xPSR: 0xa1000000 pc: 0x1000003e msp: 0x20001fe8
** Device acquired successfully
** Programming Started **
auto erase enabled
Info : ignoring flash probed value, using configured bank size
Warn : Only mass erase available, erase skipped! (psoc4 mass_erase <bank_id>)
[100%] [################################] [ Programming ]
Warn : no flash bank found for address 0x90300000
Warn : no flash bank found for address 0x90500000
Warn : no flash bank found for address 0x90600000
wrote 65600 bytes from file CYPD3171-24LQXQ_cla.hex in 2.836586s (22.584 KiB/s)
** Programming Finished **
** Verify Started **
verified 65600 bytes in 0.144861s (442.234 KiB/s)
** Verified OK **
** Resetting Target **
Info : SWD DPIDR 0x0bb11477
Error: DP initialisation failed
shutdown command invoked
Info : psoc4.dap: powering down debug domain...
Warn : Failed to power down Debug Domains
```